### PR TITLE
Fix indent, add async in "Mongoose ja Apollo"

### DIFF
--- a/src/content/osa8/osa8c.md
+++ b/src/content/osa8/osa8c.md
@@ -83,28 +83,27 @@ const resolvers = {
       // filters missing
       return Person.find({})
     },
-    findPerson: (root, args) =>
-      Person.findOne({ name: args.name})
-      },
-      Person: {
-        address: (root) => {
-          return {
-            street: root.street,
-            city: root.city
-          }
-        }
-      },
-    Mutation: {
-      addPerson: (root, args) => {
-        const person = new Person({... args})
-        return person.save()
-      },
-      editNumber: (root, args) => {
-        const person = await Person.findOne({ name: args.name })
-        person.phone = args.phone
-        return person.save()
+    findPerson: (root, args) => Person.findOne({ name: args.name })
+  },
+  Person: {
+    address: root => {
+      return {
+        street: root.street,
+        city: root.city
       }
+    }
+  },
+  Mutation: {
+    addPerson: (root, args) => {
+      const person = new Person({ ...args })
+      return person.save()
     },
+    editNumber: async (root, args) => {
+      const person = await Person.findOne({ name: args.name })
+      person.phone = args.phone
+      return person.save()
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
Fixes indent after `findPerson` and adds missing `async` to `editNumber`.

Before:
```js
const resolvers = {
  Query: {
    personCount: () => Person.collection.countDocuments(),
    allPersons: (root, args) => {
      // filters missing
      return Person.find({})
    },
    findPerson: (root, args) =>
      Person.findOne({ name: args.name})
      },
      Person: {
        address: (root) => {
          return {
            street: root.street,
            city: root.city
          }
        }
      },
    Mutation: {
      addPerson: (root, args) => {
        const person = new Person({... args})
        return person.save()
      },
      editNumber: (root, args) => {
        const person = await Person.findOne({ name: args.name })
        person.phone = args.phone
        return person.save()
      }
    },
}
```

After:

```js
const resolvers = {
  Query: {
    personCount: () => Person.collection.countDocuments(),
    allPersons: (root, args) => {
      // filters missing
      return Person.find({})
    },
    findPerson: (root, args) => Person.findOne({ name: args.name })
  },
  Person: {
    address: root => {
      return {
        street: root.street,
        city: root.city
      }
    }
  },
  Mutation: {
    addPerson: (root, args) => {
      const person = new Person({ ...args })
      return person.save()
    },
    editNumber: async (root, args) => {
      const person = await Person.findOne({ name: args.name })
      person.phone = args.phone
      return person.save()
    }
  }
}
```