### PR TITLE
Korjauksia uuden noten luomiseen

### DIFF
--- a/src/content/osa6/osa6c.md
+++ b/src/content/osa6/osa6c.md
@@ -208,9 +208,9 @@ const NewNote = (props) => {
   const addNote = async (event) => {
     event.preventDefault()
     const content = event.target.note.value // highlight-line
+    event.target.note.value = '' //highlight-line
     const newNote = await noteService.createNew(content) // highlight-line
-    props.createNote(newNote.content) // highlight-line
-    event.target.note.value = ''
+    props.createNote(newNote) // highlight-line
   }
 
   return (


### PR DESCRIPTION
Uuden noten luominen tuuttaa konsoliin virheilmoituksia, eikä uuden noten sisältö näy listassa. event.target.note.value:n nollaaminen pitää siirtää ennen noteService.createNew():tä, koska sen jälkeen event määritellään ihan toiseksi, eikä nollaus enää onnistu. props.createNote() taas vaatii parametrikseen koko newNote-olion, muuten id jää välittämättä ja konsoli huutaa puuttuvasta id:stä.