### PR TITLE
add date

### DIFF
--- a/src/content/osa4/osa4b.md
+++ b/src/content/osa4/osa4b.md
@@ -317,10 +317,12 @@ const Note = require('../models/note')
 const initialNotes = [
   {
     content: 'HTML on helppoa',
+    date: '2019-01-01T00:00:00.000+00:00',
     important: false,
   },
   {
     content: 'HTTP-protokollan tärkeimmät metodit ovat GET ja POST',
+    date: '2019-01-01T00:00:00.000+00:00',
     important: true,
   },
 ]


### PR DESCRIPTION
Earlier on the course date was specified as mandatory, will cause an error here, if not specified now [ and using what was specified earlier ].

Sample code in github is missing this requirement, but in part 3d it is in the text:
date: { 
    type: Date,
    required: true
  }