### PR TITLE
Osa3d tehtävä 3.19 ristiriita/epäselvyys korjaus

### DIFF
--- a/src/content/osa3/osa3d.md
+++ b/src/content/osa3/osa3d.md
@@ -170,7 +170,7 @@ Sovelluksen tämän hetkinen koodi on kokonaisuudessaan [githubissa](https://git
 
 #### 3.19: puhelinluettelo ja tietokanta, step7
 
-Toteuta sovelluksellesi validaatio, joka huolehtii, että backendiin voi lisätä yhdelle nimelle ainoastaan yhden numeron. Frontendin nykyisestä versiosta ei duplikaatteja voi luoda, mutta suoraan Postmanilla tai VS Coden REST clientillä se onnistuu.
+Toteuta sovelluksellesi validaatio, joka huolehtii, että backendiin ei voi lisätä nimeä joka on jo puhelinluettelossa. Frontendin nykyisestä versiosta ei duplikaatteja voi luoda, mutta suoraan Postmanilla tai VS Coden REST clientillä se onnistuu.
 
 Mongoose ei tarjoa tilanteeseen sopivaa valmista validaattoria. Käytä npm:llä asennettavaa pakettia
 [mongoose-unique-validator](https://github.com/blakehaswell/mongoose-unique-validator#readme).


### PR DESCRIPTION
Vaikuttaisi siltä, että tehtävä 3.19 sisältää ristiriidan tai epäselvyyden.

Tehtävässä mainitaan, että "Toteuta sovelluksellesi validaatio, joka huolehtii, että backendiin voi lisätä yhdelle nimelle ainoastaan yhden numeron.", mutta myöhemmin tehtävänanossa mainitaan "Jos HTTP POST -pyyntö yrittää lisätä nimeä, joka on jo puhelinluettelossa". 

Tehtävän alussa siis mainitaan, että validaation pitää huolehtia siitä, että backendiin voi lisätä vain yhden numeron per nimi, mutta myöhemin tehtävässä mainitaan, että puhelinluetteloon ei saa lisätä nimeä, joka on jo puhelinluettelossa.

Oletan tässä korjauksessa, että tehtävässä on tarkoituksena validoida, että backendiin ei voi POST pyynnöllä lähettää nimeä, joka on jo puhelinluettelossa, joka on sama ominaisuus kuin frontendissä. Myös mongoose-unique-validator, jota tehtävässä ehdotetaan käytettäväksi viittaisi myös edellämainittuun suuntaan.