### PR TITLE
Fix typo in example code

### DIFF
--- a/src/content/osa6/osa6c.md
+++ b/src/content/osa6/osa6c.md
@@ -392,7 +392,7 @@ const NewNote = (props) => {
     event.preventDefault()
     const content = event.target.note.value
     event.target.note.value = ''
-    rops.createNote(content)
+    props.createNote(content)
   }
 
   return (


### PR DESCRIPTION
`props.rops.createNote(content)` instead of `rops.createNote(content)`