### PR TITLE
fix typo in getFrontPageHtml function

### DIFF
--- a/src/content/0/en/part0b.md
+++ b/src/content/0/en/part0b.md
@@ -87,7 +87,7 @@ The HTML code of the example application has been formed dynamically, because it
 The HTML code of the homepage is as follows: 
 
 ```js
-const getFronPageHtml = (noteCount) => {
+const getFrontPageHtml = (noteCount) => {
   return(`
     <!DOCTYPE html>
     <html>


### PR DESCRIPTION
I saw there was a typo in the example code, where the function is first defined as 'getFronPageHtml' but it later called using 'getFrontPageHtml'.