### PR TITLE
Update osa2c.md

### DIFF
--- a/src/content/2/fi/osa2c.md
+++ b/src/content/2/fi/osa2c.md
@@ -246,7 +246,9 @@ Parametrissa oli siis hienoinen ero. <i>axios</i> tallennettiin sovelluksen ajon
 
 ### Axios ja promiset
 
-Olemme nyt valmiina käyttämään axiosia. Jatkossa oletetaan että <i>json-server</i> on käynnissä portissa 3001.
+Olemme nyt valmiina käyttämään axiosia. Jatkossa oletetaan että <i>json-server</i> on käynnissä portissa 3001. Lisäksi varsinainen React-sovellus tulee käynnistää erikseen, erilliseen komentorivi-ikkunaan komennolla:
+
+```npm start```
 
 Kirjaston voi ottaa käyttöön samaan tapaan kuin esim. React otetaan käyttöön, eli sopivalla <em>import</em>-lauseella.
 


### PR DESCRIPTION
Lisätty riveille 249-251:

" Lisäksi varsinainen React-sovellus tulee käynnistää erikseen, erilliseen komentorivi-ikkunaan komennolla:

```npm start```"

Itsellä meni puoli päivää tätä ihmetellessä, kun en osannut päätellä mistään, että serverin lisäksi tulee myös käynnistää itse react-appi.