### PR TITLE
Changed counter.value to counter

### DIFF
--- a/src/content/1/en/part1c.md
+++ b/src/content/1/en/part1c.md
@@ -197,7 +197,7 @@ ReactDOM.render(
 The root component is given the value of the counter in the _counter_ prop. The root component renders the value to the screen. But what happens when the value of _counter_ changes? Even if we were to add the command
 
 ```js
-counter.value += 1
+counter += 1
 ```
 
 the component won't re-render. We can get the component to re-render by calling the _ReactDOM.render_ method a second time, e.g. in the following way:


### PR DESCRIPTION
Counter.value is confusing because "counter" has been a simple variable in the preceding code and not an object with a property called "value". A little further down it is "counter += 1" again and I don't see how it could be helpful to have this one instance different.