### PR TITLE
Make the header click through when transparent

### DIFF
--- a/src/components/Header/Header.scss
+++ b/src/components/Header/Header.scss
@@ -10,8 +10,13 @@
   padding-top: 1.444rem;
   padding-bottom: 1rem;
   transition: all 0.2s ease-in-out;
+
+  &--small {
+    pointer-events: none;
+  }
 }
 
 .header__logo {
   margin: 0 10px;
+  pointer-events: auto;
 }


### PR DESCRIPTION
Issue #160

The header should not consume mouse events when it is transparent