### PR TITLE
Update part1b.md

### DIFF
--- a/src/content/1/en/part1b.md
+++ b/src/content/1/en/part1b.md
@@ -110,7 +110,7 @@ console.log(m2)
 // [ '<li>1</li>', '<li>2</li>', '<li>3</li>' ] is printed
 ```
 
-Here an array filled with integer values is transformed into an array containing HTML using the map method. In [part2](/part2) of this course, we will see that map is used quite frequently in React.
+Here an array filled with integer values is transformed into an array containing strings of HTML using the map method. In [part2](/part2) of this course, we will see that map is used quite frequently in React.
 
 Individual items of an array are easy to assign to variables with the help of [destructuring assignment](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Destructuring_assignment).
 


### PR DESCRIPTION
I think the original usage of the following text is misleading:
```
const m2 = t.map(value => '<li>' + value + '</li>')
console.log(m2)  
// [ '<li>1</li>', '<li>2</li>', '<li>3</li>' ] is printed
Here an array filled with integer values is transformed into an array containing HTML using the map method.
```
Arrays can also contain HTML nodes which this mistakenly alludes to but in actuality the array elements are strings.