### PR TITLE
Change "contributor" to "collaborator"

### DIFF
--- a/src/content/0/en/part0a.md
+++ b/src/content/0/en/part0a.md
@@ -111,7 +111,7 @@ If you have previously passed the course exam (excluding the exam for 3 credit c
 
 The exercises are submitted through GitHub and marking the exercises as done on the [submission system](https://studies.cs.helsinki.fi/fullstackopen2019).
 
-If you are submitting exercises from different parts to the same repository, use some sensible system for naming your directories. You can of course create a new repository for each part.  If you are using a private repository, add _mluukkai_ as a contributor. 
+If you are submitting exercises from different parts to the same repository, use some sensible system for naming your directories. You can of course create a new repository for each part.  If you are using a private repository, add _mluukkai_ as a collaborator. 
 
 Exercises are submitted **one part at a time**. When you have once submitted exercises for a part, you can no longer submit any more exercises for that part. 
 


### PR DESCRIPTION
As far as I saw there is no way to add contributors in Git. The setting I found for private repos is called "Collaborators". 
If this is right, this change might avoid a bit of confusion.