### PR TITLE
Changed "npm run" to "npm run watch"

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -996,7 +996,7 @@ Notice that the forward slash in the route <i>api/persons</i> is not a special c
 The application must be started with the command _npm start_.
 
 
-The application must also offer an _npm run_ command that will run the application and restart the server whenever changes are made and saved to a file in the source code.
+The application must also offer an _npm run watch_ command that will run the application and restart the server whenever changes are made and saved to a file in the source code.
 
 
 #### 3.2: Phonebook backend step2


### PR DESCRIPTION
To my knowledge, "run" is not among the npm supported “scripts” properties of the package.json file, like "start" or "test".
https://docs.npmjs.com/misc/scripts#description
So something like "npm run" won't work at all. We could add a "run" property to "scripts" property of the package.json and then execute it with "npm run run", but that is confusing and doesn't make sense.
"watch" makes more sense, because that's what "nodemon" is doing.

So the solution, in my humble opinion, should look like the following:
  "scripts": {
    ...
    "start": "node index.js",
    "watch": "nodemon index.js",
    ...
  }

And students should be asked to create a solution that works for the following two commands:
"npm start"
"npm run watch"

I'm not an expert. It may be that I just don't know how to solve the problem as it is right now.
Thank you for letting me learn while (hopefully) adding something to the project.