### PR TITLE
Corrected internal link

### DIFF
--- a/src/content/3/en/part3c.md
+++ b/src/content/3/en/part3c.md
@@ -618,7 +618,7 @@ Change the fetching of all phonebook entries so that the data is <i>fetched from
 
 Verify that the frontend works after the changes have been made.
 
-In the following exercises, write all Mongoose-specific code into its own module, just like we did in the chapter [Database configuration into its own module](/osa3/tietojen_tallettaminen_mongo_db_tietokantaan#tietokantamaarittelyjen-eriyttaminen-moduuliksi)
+In the following exercises, write all Mongoose-specific code into its own module, just like we did in the chapter [Database configuration into its own module](/en/part3/saving_data_to_mongo_db#database-configuration-into-its-own-module)
 
 #### 3.13: Phonebook database, step2
 


### PR DESCRIPTION
It was linked to the finish version of the course. Change it to its English equivalent.