### PR TITLE
Highlight the change of the initial note-state after adding axios

### DIFF
--- a/src/content/2/en/part2c.md
+++ b/src/content/2/en/part2c.md
@@ -375,7 +375,7 @@ import axios from 'axios' // highlight-line
 import Note from './components/Note'
 
 const App = () => {
-  const [notes, setNotes] = useState([]) 
+  const [notes, setNotes] = useState([]) // highlight-line
   const [newNote, setNewNote] = useState('')
   const [showAll, setShowAll] = useState(true)
 


### PR DESCRIPTION
I just happened to run across this "error" while following the examples. 

The provided example code does not highlight that you need to update `const [notes, setNotes] = useState(props.notes)` to this: `const [notes, setNotes] = useState([])` when mimicking a GET with axios. In the original example, the notes were still passed as props: however, this was removed during the previous section in the tutorial, resulting in a long list of errors that the reader might confuse the reader. As this was not highlighted, I glanced over it causing me to be confused for a minute when I got a rather vague error message.

Hope it helps! : )