### PR TITLE
Update part4b.md

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -1118,16 +1118,16 @@ const api = supertest(app)
 
 const Note = require('../models/note')
 
+beforeEach(async () => {
+  await Note.deleteMany({})
+
+  const noteObjects = helper.initialNotes
+    .map(note => new Note(note))
+  const promiseArray = noteObjects.map(note => note.save())
+  await Promise.all(promiseArray)
+})
+
 describe('when there is initially some notes saved', () => {
-  beforeEach(async () => {
-    await Note.deleteMany({})
-
-    const noteObjects = helper.initialNotes
-      .map(note => new Note(note))
-    const promiseArray = noteObjects.map(note => note.save())
-    await Promise.all(promiseArray)
-  })
-
   test('notes are returned as json', async () => {
     await api
       .get('/api/notes')
@@ -1223,7 +1223,7 @@ describe('when there is initially some notes saved', () => {
   })
 
   describe('deletion of a note', () => {
-    test('succeeds with status code 200 if id is valid', async () => {
+    test('succeeds with status code 204 if id is valid', async () => {
       const notesAtStart = await helper.notesInDb()
       const noteToDelete = notesAtStart[0]
 


### PR DESCRIPTION
These 2 tests fail because we aren't resetting the db before every test. Currently mongo resets in the first describe block only.

1. addition of a new note fails with status code 400 : The last expectation that `notesAtEnd` and `initialNotes` lengths fails because the previous test `addition of a new note succeeds with valid data` adds a new note so there are 3 notes instead of 2.

2. deletion of a note succeeds with status code 204 if id is valid : Again first expectation that `notesAtEnd` will be 1 fails because we have the new note added from previous test. 

Fix: Move `beforeEach` to top-level to make mongo reset for all tests.