### PR TITLE
partnavigation/part titles: Web-apps -> Web apps

### DIFF
--- a/src/content/partnavigation/partnavigation.js
+++ b/src/content/partnavigation/partnavigation.js
@@ -59,7 +59,7 @@ module.exports = {
   en: {
     '0': {
       a: 'General info',
-      b: 'Fundamentals of Web-apps',
+      b: 'Fundamentals of Web apps',
     },
     '1': {
       a: 'Introduction to React',


### PR DESCRIPTION
A hyphen is not usually used here in English.