### PR TITLE
Correct object name in axios promise example

### DIFF
--- a/src/content/2/en/part2c.md
+++ b/src/content/2/en/part2c.md
@@ -295,7 +295,7 @@ The following is printed to the console:
 
 ![](../../images/2/17e.png)
 
-The Javascript runtime environment calls the callback function registered by the <em>then</em> method providing it with a <em>result</em> object as a parameter. The <em>result</em> object contains all the essential data related to the response of an HTTP GET request, which would include the returned <i>data</i>, <i>status code</i>, and <i>headers</i>.
+The Javascript runtime environment calls the callback function registered by the <em>then</em> method providing it with a <em>response</em> object as a parameter. The <em>response</em> object contains all the essential data related to the response of an HTTP GET request, which would include the returned <i>data</i>, <i>status code</i>, and <i>headers</i>.
 
 Storing the promise object in a variable is generally unnecessary, and it's instead common to chain the <em>then</em> method call to the axios method call, so that it follows it directly:
 


### PR DESCRIPTION
Object is apparently called `response`, not `result`.