### PR TITLE
(osa6a) Pass handleClick prop instead of onClick

### DIFF
--- a/src/content/6/fi/osa6a.md
+++ b/src/content/6/fi/osa6a.md
@@ -976,7 +976,7 @@ const Notes = ({ store }) => {
         <Note
           key={note.id}
           note={note}
-          onClick={() => 
+          handleClick={() => 
             store.dispatch(toggleImportanceOf(note.id))
           }
         />


### PR DESCRIPTION
The Notes components renders a Note component which is expecting to receive a 'handleClick' method as a prop. In the code example the prop is incorrectly named 'onClick' which won't do anything inside the Note component.