### PR TITLE
CreateNew -> CreateNote

### DIFF
--- a/src/content/6/fi/osa6c.md
+++ b/src/content/6/fi/osa6c.md
@@ -369,10 +369,10 @@ export default connect(
 
 Ratkaisu on elegantti, muistiinpanojen alustuslogiikka on eriytetty kokonaan React-komponenttien ulkopuolelle.
 
-Uuden muistiinpanon lisäävä action creator _createNew_ on seuraavassa
+Uuden muistiinpanon lisäävä action creator _createNote_ on seuraavassa
 
 ```js
-export const createNew = content => {
+export const createNote = content => {
   return async dispatch => {
     const newNote = await noteService.createNew(content)
     dispatch({


### PR DESCRIPTION
ActionCreator is named CreateNote, not CreateNew in example source.

Source: https://github.com/fullstackopen-2019/redux-notes/blob/part6-6/src/reducers/noteReducer.js

Material: 
![image](https://user-images.githubusercontent.com/16867703/62127198-28490700-b2da-11e9-96d5-2adb12258ea8.png)

(Snippet below refers to a actionCreator called `createNote`)