### PR TITLE
Make sure students use a compatible Node version

### DIFF
--- a/src/content/4/en/part4a.md
+++ b/src/content/4/en/part4a.md
@@ -398,6 +398,12 @@ Turn the application into a functioning <i>npm</i> project. In order to keep you
 
 Verify that it is possible to add blogs to list with Postman or the VS Code REST client and that the application returns the added blogs at the correct endpoint.
 
+Ensure that your Node version is newer than 9.6 by running 
+```bash 
+node-v 
+```
+Earlier versions may cause unexpected errors.
+
 
 #### 4.2 Blog list, step2
 


### PR DESCRIPTION
I was using an older version of Node accidentally (using nvm) and I was getting an 'listener must be a function error'.
Spent some time until I found this answer on stackoverflow; https://stackoverflow.com/a/51755440/4900839

Since this is the first lesson on Nodejs it might be a good idea to warn students about using an updated version of Nodejs (>9.6 or LTS preferrably)