### PR TITLE
Fix typo about age vs changing year of birth

### DIFF
--- a/src/content/1/en/part1c.md
+++ b/src/content/1/en/part1c.md
@@ -38,7 +38,7 @@ const App = () => {
 
 ### Component helper functions
 
-Let's expand our <i>Hello</i> component so that it guesses the age of the person being greeted:
+Let's expand our <i>Hello</i> component so that it guesses the year of birth of the person being greeted:
 
 ```js
 const Hello = (props) => {


### PR DESCRIPTION
Fix a typo about referring to guessing age when we're computing birth year.