### PR TITLE
osa1c & osa1d: rename Button prop handleClick to onClick

### DIFF
--- a/src/content/1/fi/osa1c.md
+++ b/src/content/1/fi/osa1c.md
@@ -705,7 +705,7 @@ Tehdään seuraavaksi napeille tarkoitettu komponentti <i>Button</i>. Napille on
 
 ```js
 const Button = (props) => (
-  <button onClick={props.handleClick}>
+  <button onClick={props.onClick}>
     {props.text}
   </button>
 )
@@ -714,8 +714,8 @@ const Button = (props) => (
 ja hyödynnetään taas destrukturointia ottamaan <i>props</i>:in tarpeelliset kentät suoraan:
 
 ```js
-const Button = ({ handleClick, text }) => (
-  <button onClick={handleClick}>
+const Button = ({ onClick, text }) => (
+  <button onClick={onClick}>
     {text}
   </button>
 )
@@ -734,15 +734,15 @@ const App = (props) => {
       <Display counter={counter}/>
       // highlight-start
       <Button
-        handleClick={() => setToValue(counter + 1)}
+        onClick={() => setToValue(counter + 1)}
         text='plus'
       />
       <Button
-        handleClick={() => setToValue(counter - 1)}
+        onClick={() => setToValue(counter - 1)}
         text='minus'
       />
       <Button
-        handleClick={() => setToValue(0)}
+        onClick={() => setToValue(0)}
         text='zero'
       />
       // highlight-end

--- a/src/content/1/fi/osa1d.md
+++ b/src/content/1/fi/osa1d.md
@@ -330,8 +330,8 @@ const History = (props) => {
 }
 
 // highlight-start
-const Button = ({ handleClick, text }) => (
-  <button onClick={handleClick}>
+const Button = ({ onClick, text }) => (
+  <button onClick={onClick}>
     {text}
   </button>
 )
@@ -357,8 +357,8 @@ const App = (props) => {
       <div>
         {left}
         // highlight-start
-        <Button handleClick={handleLeftClick} text='left' />
-        <Button handleClick={handleRightClick} text='right' />
+        <Button onClick={handleLeftClick} text='left' />
+        <Button onClick={handleRightClick} text='right' />
         // highlight-end
         {right}
         <History allClicks={allClicks} />


### PR DESCRIPTION
Rename prop handleClick to onClick to comply with the text after the code snippet. Also matches the English version of this page.