### PR TITLE
osa1d: rename prop onClick to handleClick

### DIFF
--- a/src/content/1/fi/osa1d.md
+++ b/src/content/1/fi/osa1d.md
@@ -972,9 +972,9 @@ const App = props => {
   return (
     <div>
       <Display value={value} />
-      <Button onClick={() => setToValue(1000)} text="thousand" />
-      <Button onClick={() => setToValue(0)} text="reset" />
-      <Button onClick={() => setToValue(value + 1)} text="increment" />
+      <Button handleClick={() => setToValue(1000)} text="thousand" />
+      <Button handleClick={() => setToValue(0)} text="reset" />
+      <Button handleClick={() => setToValue(value + 1)} text="increment" />
     </div>
   )
 }
@@ -1001,9 +1001,9 @@ const App = props => {
   return (
     <div>
       <Display value={value} />
-      <Button onClick={() => setToValue(1000)} text="thousand" />
-      <Button onClick={() => setToValue(0)} text="reset" />
-      <Button onClick={() => setToValue(value + 1)} text="increment" />
+      <Button handleClick={() => setToValue(1000)} text="thousand" />
+      <Button handleClick={() => setToValue(0)} text="reset" />
+      <Button handleClick={() => setToValue(value + 1)} text="increment" />
     </div>
   )
 }


### PR DESCRIPTION
More onClick vs. handleClick confusion...

Here the Button component expects a handleClick prop so we should pass that prop when rendering the component. Alternatively we could change Button to expect an onClick prop like earlier in this chapter but since the course material above the code snippet contains an image using the handleClick prop it's probably clearer to use handleClick. Also the English version uses handleClick here.