### PR TITLE
Update part1d.md

### DIFF
--- a/src/content/1/en/part1d.md
+++ b/src/content/1/en/part1d.md
@@ -845,20 +845,20 @@ We can use the same trick to define event handlers that set the state of the com
 const App = (props) => {
   const [value, setValue] = useState(10)
   
-  // hightlight-start
+  // highlight-start
   const setToValue = (newValue) => () => {
     setValue(newValue)
   }
-  // hightlight-end
+  // highlight-end
   
   return (
     <div>
       {value}
-      // hightlight-start
+      // highlight-start
       <button onClick={setToValue(1000)}>thousand</button>
       <button onClick={setToValue(0)}>reset</button>
       <button onClick={setToValue(value + 1)}>increment</button>
-      // hightlight-end
+      // highlight-end
     </div>
   )
 }


### PR DESCRIPTION
This PR corrects a typo in comments that are supposed to add highlighting to example code in Part 1d.

Currently this gets rendered like this:

![image](https://user-images.githubusercontent.com/15220906/63718154-d5636080-c841-11e9-861b-615638600498.png)

whereas I believe it should look more like this earlier example (I did not build the site with the changes myself):

![image](https://user-images.githubusercontent.com/15220906/63718187-eb712100-c841-11e9-8f0f-e0658c6e1901.png)