### PR TITLE
BodyParser package isn't necessary

### DIFF
--- a/src/content/3/en/part3a.md
+++ b/src/content/3/en/part3a.md
@@ -765,9 +765,8 @@ Let's import body-parser and implement an initial handler for dealing with the H
 ```js
 const express = require('express')
 const app = express()
-const bodyParser = require('body-parser')
 
-app.use(bodyParser.json())
+app.use(express.json())
 
 //...
 


### PR DESCRIPTION
In Express v4.x, the `body-parser` was incorporated in the core express now you can use the body-parsing middleware using `express.json()` or `express.urlencoded()`.

Source:
https://expressjs.com/en/api.html#express.json