### PR TITLE
Avoid mutating cached array contents

### DIFF
--- a/src/content/8/fi/osa8e.md
+++ b/src/content/8/fi/osa8e.md
@@ -352,10 +352,9 @@ const App = () => {
 
     const dataInStore = client.readQuery({ query: ALL_PERSONS })
     if (!includedIn(dataInStore.allPersons, addedPerson)) {
-      dataInStore.allPersons.push(addedPerson)
       client.writeQuery({
         query: ALL_PERSONS,
-        data: dataInStore
+        data: { allPersons : dataInStore.allPersons.concat(addedPerson) }
       })
     }   
   }


### PR DESCRIPTION
Instead return a new array with the modified contents. React might not be able to show the updated state if the cached array is mutated directly.