### PR TITLE
Change broken Flux docs link to valid new link

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -13,7 +13,7 @@ So far, we have followed the state management conventions recommended by React. 
 ### Flux-architecture
 
 
-Facebook developed the [Flux](https://facebook.github.io/flux/docs/in-depth-overview.html#content)- architecture to make state management easier. In Flux, the state is separated completely from the React-components into its own <i>stores</i>.
+Facebook developed the [Flux](https://facebook.github.io/flux/docs/in-depth-overview/)- architecture to make state management easier. In Flux, the state is separated completely from the React-components into its own <i>stores</i>.
 State in the store is not changed directly, but with different <i>actions</i>.
 
 


### PR DESCRIPTION
https://facebook.github.io/flux/docs/in-depth-overview.html#content is no longer found, so the new link should just go to https://facebook.github.io/flux/docs/in-depth-overview/