### PR TITLE
Clarified inline style limitations sentence

### DIFF
--- a/src/content/2/en/part2e.md
+++ b/src/content/2/en/part2e.md
@@ -312,7 +312,7 @@ const App = () => {
 ```
 
 
-Inline selectors come with certain limitations. For instance, so-called pseudo selectors can't be used straightforwardly.
+Inline styles come with certain limitations. For instance, so-called [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) can't be used straightforwardly.
 
 
 Inline styles and some of the other ways of adding styles to React components go completely against the grain of old conventions. Traditionally, it has been considered the best practice to entirely separate CSS from the content (HTML) and functionality (JavaScript). According to this older school of thought, the goal was to write CSS, HTML, and JavaScript into their separate files.


### PR DESCRIPTION
I found this sentence confusing. It seems like it's probably using the wrong terms, so the changes include

- Inline selector -> Inline style
- Pseudo selectors -> Pseudo-class, with link to docs

I don't think "inline selector" makes sense in the context of inline styles in react, since the CSS properties are being assigned directly to the component/element, so there wouldn't be any selectors involved. Which is why the pseudo-class sentence makes sense once that wording is updated too.