### PR TITLE
Update part4c.md

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -295,6 +295,7 @@ It takes much less effort to write automated tests, and it will make the develop
 Our initial tests could look like this:
 
 ```js
+const bcrypt = require('bcrypt')
 const User = require('../models/user')
 
 //...
@@ -302,7 +303,12 @@ const User = require('../models/user')
 describe('when there is initially one user at db', () => {
   beforeEach(async () => {
     await User.deleteMany({})
-    const user = new User({ username: 'root', password: 'sekret' })
+
+    const password = 'secret'
+    const saltRounds = 10
+    const passwordHash = await bcrypt.hash(password, saltRounds)
+
+    const user = new User({ username: 'root', passwordHash: passwordHash })
     await user.save()
   })
 

--- a/src/content/4/fi/osa4c.md
+++ b/src/content/4/fi/osa4c.md
@@ -266,7 +266,12 @@ const User = require('../models/user')
 describe('when there is initially one user at db', () => {
   beforeEach(async () => {
     await User.deleteMany({})
-    const user = new User({ username: 'root', password: 'sekret' })
+
+    const password = 'sekret'
+    const saltRounds = 10
+    const passwordHash = await bcrypt.hash(password, saltRounds)
+
+    const user = new User({ username: 'root', passwordHash: passwordHash })
     await user.save()
   })
 


### PR DESCRIPTION
Manual creation of User in user tests was specifying unused password field instead of passwordHash. Though it doesn't cause any of the tests in the example to fail (because no tests are written to check passwords are hashed properly), it could cause problems if the example were extended.