### PR TITLE
"without" instead of "with" the debugger command

### DIFF
--- a/src/content/1/en/part1d.md
+++ b/src/content/1/en/part1d.md
@@ -456,7 +456,7 @@ Once the cause of the bug is discovered you can remove the _debugger_ command an
 
 The debugger also enables us to execute our code line by line with the controls found in the right-hand side of the <i>Source</i> tab.
 
-You can also access the debugger with the _debugger_ command by adding break points in the <i>Sources</i> tab. Inspecting the values of the component's variables can be done in the _Scope_-section:
+You can also access the debugger without the _debugger_ command by adding break points in the <i>Sources</i> tab. Inspecting the values of the component's variables can be done in the _Scope_-section:
 
 ![](../../images/1/9a.png)
 


### PR DESCRIPTION
Maybe I am misunderstanding this, but when you say "You can also access the debugger **WITH** the debugger command by adding break points in the Sources tab.", don't you mean "You can also access the debugger **WITHOUT** the debugger command by adding break points in the Sources tab."? The break points enables you to stop the execution of the script without the debugger command