### PR TITLE
Update the link to currying in JS

### DIFF
--- a/src/content/1/fi/osa1c.md
+++ b/src/content/1/fi/osa1c.md
@@ -636,7 +636,7 @@ Ensimmäisellä kutsulla "konfiguroidaan" varsinainen funktio, sijoittamalla osa
 () => setCounter(5)
 ```
 
-Tässä näytetty tapa soveltaa funktioita palauttavia funktioita on oleellisesti sama asia mistä funktionaalisessa ohjelmoinnissa käytetään termiä [currying](http://www.datchley.name/currying-vs-partial-application/). Termi currying ei ole lähtöisin funktionaalisen ohjelmoinnin piiristä vaan sillä on juuret [syvällä matematiikassa](https://en.wikipedia.org/wiki/Currying).
+Tässä näytetty tapa soveltaa funktioita palauttavia funktioita on oleellisesti sama asia mistä funktionaalisessa ohjelmoinnissa käytetään termiä [currying](https://medium.com/javascript-scene/curry-and-function-composition-2c208d774983). Termi currying ei ole lähtöisin funktionaalisen ohjelmoinnin piiristä vaan sillä on juuret [syvällä matematiikassa](https://en.wikipedia.org/wiki/Currying).
 
 Jo muutamaan kertaan mainittu termi <i>funktionaalinen ohjelmointi</i> ei ole välttämättä kaikille tässä vaiheessa tuttu. Asiaa avataan hiukan kurssin kuluessa, sillä React tukee ja osin edellyttää funktionaalisen tyylin käyttöä.
 


### PR DESCRIPTION
It seems that the link for currying is broken. Replaced with another one. There could be something more suitable to link here, but anyway the current link is broken now. :)