### PR TITLE
Corrected double negation comment

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -104,7 +104,7 @@ const counterReducer = (state = 0, action) => {
       return state - 1
     case 'ZERO':
       return 0
-    default: // if none of the above does not match, code comes here
+    default: // if none of the above matches, code comes here
     return state
   }
 }


### PR DESCRIPTION
"If none of the above does not match" is a form of double negative [0] which might confuse the reader.

[0] https://en.wikipedia.org/wiki/Double_negative