### PR TITLE
Uniform names of action creator functions

### DIFF
--- a/src/content/6/en/part6a.md
+++ b/src/content/6/en/part6a.md
@@ -1011,7 +1011,7 @@ import noteReducer from './reducers/noteReducer'
 A module can have only <i>one default export</i>, but multiple "normal" exports
 
 ```js
-export const noteCreation = content => {
+export const createNote = (content) => {
   // ...
 }
 
@@ -1024,7 +1024,7 @@ export const toggleImportanceOf = (id) => {
 Normally (not as defaults) exported functions can be imported with the curly brace syntax:
 
 ```js
-import { noteCreation } from './../reducers/noteReducer'
+import { createNote } from './../reducers/noteReducer'
 ```
 
 Let's separate creating new notes into its own component. 


### PR DESCRIPTION
The action creator for new notes is called 'createNote' through all of the document, except in two instances where it is called 'noteCreation'. This can generate confusion.

Also, arrow functions parameters in action creators are always wrapped into round brackets through all of the document, except for an instance of 'content' which is not. Uniformed also that to the document standard.