### PR TITLE
Use useLazyQuery instead of ApolloConsumer

### DIFF
--- a/src/content/8/fi/osa8d.md
+++ b/src/content/8/fi/osa8d.md
@@ -360,6 +360,7 @@ Tietyn genren kirjoihin rajoittamisen voi tehdä kokonaan React-sovelluksen puol
 
 Tämä **tehtävä on haastava** ja niin kurssin tässä vaiheessa jo kuuluukin olla. Muutama vihje
 - Komponetin <i>Query</i> tai hookin <i>useQuery</i> käytön sijaan saattaa olla parempi tehdä kyselyitä suoraan _client_-oliolla, jonhon päästään käsiksi komponentin [ApolloConsumer](https://www.apollographql.com/docs/react/essentials/queries.html#manual-query) tai hookilla [useApolloClient](https://github.com/trojanowski/react-apollo-hooks#useapolloclient), katso lisää [täältä](/osa8/react_ja_graph_ql#nimetyt-kyselyt-ja-muuttujat).
+- Toinen vaihtoehto voi olla Apollo Clientin hookien uudehko lisäys <i>useLazyQuery</i>, katso lisää [täältä](https://www.apollographql.com/docs/react/data/queries/#executing-queries-manually). 
 - GraphQL-kyselyjen tuloksia kannattaa joskus tallentaan komponentin tilaan.
 - Huomaa, että voit tehdä GraphQL-kyselyjä <i>useEffect</i>-hookissa.
 - <i>useEffect</i>-hookin [toisesta parametrista](https://reactjs.org/docs/hooks-reference.html#conditionally-firing-an-effect) voi olla tehtävässä apua, se tosin riippuu käyttämästäsi lähestymistavasta.


### PR DESCRIPTION
useLazyQuery tarjoaa kätevähkön täysin hookeihin perustuvan vaihtoehdon ApolloConsumerille, jolla koodista tulee siistimpää.