### PR TITLE
Typo / wrong note id

### DIFF
--- a/src/content/4/en/part4c.md
+++ b/src/content/4/en/part4c.md
@@ -94,7 +94,7 @@ Document databases do not demand the foreign key to be stored in the note resour
   {
     username: 'hellas',
     _id: 141414,
-    notes: [141414],
+    notes: [221244],
   },
 ]
 ```


### PR DESCRIPTION
Node `id` was the same as the user `id` for username `hellas`.