### PR TITLE
A small change to .eslintrc.js

### DIFF
--- a/src/content/5/fi/osa5b.md
+++ b/src/content/5/fi/osa5b.md
@@ -666,8 +666,9 @@ module.exports = {
             "error", { "before": true, "after": true }
         ],
         "no-console": 0,
-        "react/prop-types": 0
+        "react/prop-types": 0,
         // highlight-end
+        "react/display-name": 0
     }
 };
 ```


### PR DESCRIPTION
Ainakin omalla kohdalla tuo Eslint valitti ominaisuuden `displayName` puutteesta niissä komponenteissa, mitkä oli määritelty tuon `React.forwardRef` kautta. Ongelman syvällisemmän syynäämisen sijaan - mikä ei tuntunut pahemmin vastaavan tarkoitusta - tämä muutos poisti kyseisen herjan ja antoi koodin säilyä paremmin materiaalia vastaavana.