### PR TITLE
Semi-broken link at exercise 4.14 (2 h3 with the same id)

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -1292,7 +1292,7 @@ Implement functionality for updating the information of an individual blog post.
 Use async/await.
 
 
-The application mostly needs to update the amount of <i>likes</i> for a blog post. You can implement this functionality the same way that we implemented updating notes in [part 3](/en/part3/saving_data_to_mongo_db#other-operations).
+The application mostly needs to update the amount of <i>likes</i> for a blog post. You can implement this functionality the same way that we implemented updating notes in [part 3](/en/part3/saving_data_to_mongo_db#other-operations2).
 
 
 Feel free to implement tests for the functionality if you want to. Otherwise verify that the functionality works with Postman or some other tool.


### PR DESCRIPTION
At the 4.14 exercise there is a link to /en/part3/saving_data_to_mongo_db#other-operations which isn't the right one because there are 2 h3 with that id and it should link to the second one (the one where it teaches you how to update a note, not to create one). I don't know what change to propose because more files should be updated and I don't want to break something but it's something to look at.