### PR TITLE
Part 4b - Added 'date' field to 'test_helper.js' example

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -644,10 +644,12 @@ const Note = require('../models/note')
 const initialNotes = [
   {
     content: 'HTML is easy',
+    date: new Date(),
     important: false
   },
   {
     content: 'Browser can execute only Javascript',
+    date: new Date(),
     important: true
   }
 ]


### PR DESCRIPTION
Validation failed because the date field is required.