### PR TITLE
Update section 'setup' in osa5c.md

### DIFF
--- a/src/content/5/fi/osa5c.md
+++ b/src/content/5/fi/osa5c.md
@@ -231,42 +231,6 @@ console.log src/components/Note.test.js:21
   </li>
 ```
 
-### setup
-
-react-testing-library:n manuaali kehoittaa kutsumaan jokaisen testin jälkeen metodia
-[cleanup](https://testing-library.com/docs/react-testing-library/api#cleanup). Hoidimme asian lisäämällä testitiedostoon [afterEach](https://jestjs.io/docs/en/setup-teardown)-määreen, joka kutsuu metodia:
-
-```js 
-import React from 'react'
-import '@testing-library/jest-dom/extend-expect' // highlight-line
-import { render, cleanup } from '@testing-library/react'
-import { prettyDOM } from '@testing-library/dom' 
-import Note from './Note'
-
-afterEach(cleanup)  // highlight-line
-```
-
-Voisimme toistaa saman kaikkiin testitiedostoihin. Parempi vaihtoehto on kuitenkin [konfiguroida](https://testing-library.com/docs/react-testing-library/setup) cleanup tapahtumaan automaattisesti. Tehdään konfiguraatiota varten tiedosto <i>src/setupTests.js</i> jolla on seuraava sisältö:
-
-```js
-import '@testing-library/jest-dom/extend-expect'
-import '@testing-library/react/cleanup-after-each'
-```
-
-Nyt pääsemme eroon molemmista ylläolevan testikoodin korostetuista riveistä.
-
-**HUOM** mikäli testejä suoritettaessa ei löydetä tiedostossa <i>src/setupTests.js</i> tehtyjä konfiguraatioita, auttaa seuraavan asetuksen lisääminen tiedostoon package.json:
-
-```
-  "jest": {
-    ...
-    "setupFiles": [
-      "<rootDir>/src/setupTests.js"
-    ],
-    ...
-  }
-```
-
 ### Nappien painelu testeissä
 
 Sisällön näyttämisen lisäksi toinen <i>Note</i>-komponenttien vastuulla oleva asia on huolehtia siitä, että painettaessa noten yhteydessä olevaa nappia, tulee propsina välitettyä tapahtumankäsittelijäfunktiota _toggleImportance_ kutsua.


### PR DESCRIPTION
Seems that '@testing-library/react/cleanup-after-each' is deprecated. When I made setupTests.js file described in the text and run tests following text was logged to the console:
```
console.warn node_modules/@testing-library/react/cleanup-after-each.js:1
    The module `@testing-library/react/cleanup-after-each` has been deprecated and no longer does anything (it is not needed). You no longer need to import this module and can safely remove any import or configuration which imports this module
```
Docs say that cleanup is made now automatically after each test when Jest is used, so maybe whole paragraph could be removed.
https://testing-library.com/docs/react-testing-library/api#cleanup
https://testing-library.com/docs/react-testing-library/setup#skipping-auto-cleanup