### PR TITLE
Add explicit instruction for using PUT on 4.14

### DIFF
--- a/src/content/4/fi/osa4b.md
+++ b/src/content/4/fi/osa4b.md
@@ -1150,7 +1150,7 @@ Saat toteuttaa ominaisuudelle testit jos haluat. Jos et, varmista ominaisuuden t
 
 #### 4.14* blogilistan laajennus, step2
 
-Toteuta sovellukseen mahdollisuus yksittäisen blogin muokkaamiseen.
+Toteuta sovellukseen mahdollisuus yksittäisen blogin muokkaamiseen käyttämällä PUT-operaatiota.
 
 Käytä async/awaitia.
 


### PR DESCRIPTION
Adding explicit instruction to use PUT over PATCH is beneficial because 5.7 tasks students to update blog entry by using PUT.