### PR TITLE
Link and typos fixed in English FAQ

### DIFF
--- a/src/content/pages/faq.json
+++ b/src/content/pages/faq.json
@@ -69,15 +69,15 @@
   ],
   "en": [
     {
-      "title": "Will there be a new course 2020?",
+      "title": "Will there be a new course in 2020?",
       "text": [
-        "Yes, the new version of the course will start 15.3.2020.<br><br>There won't be major changes in the course content. The gereatest change shall be in part 5, where integration testing of frontend will be replaced by E2E testing using Cypres.io. <br><br>There will also be an entirely new part about Typescript.<br><br>The 2019 version can be expanded in the  2020 version, see more <a href='/part0/general_info#expanding-a-previously-completed-course'>here</a>. "
+        "Yes, the new version of the course will start on 15.3.2020.<br><br>There won't be major changes in the course content. The greatest change shall be in part 5, where integration testing of frontend will be replaced by E2E testing using Cypress.io. <br><br>There will also be an entirely new part about Typescript.<br><br>The 2019 version can be expanded in the  2020 version, see more <a href='/en/part0/general_info#expanding-a-previously-completed-course'>here</a>. "
       ]
     },
     {
       "title": "How do I sign up for the course?",
       "text": [
-        "You don't have to sign up until you want to do the course exam. The exam is done to the Moodle-system of the Open University. You can find more information <a href='/en/part0/general_info#grading'>here</a>. Please note that only persons with Finnish social security number can get take part to exam and get official ECTS credits. For the course certificate signup or Finnish social security number are not needed."
+        "You don't have to sign up until you want to do the course exam. The exam is done in the Moodle-system of the Open University. You can find more information <a href='/en/part0/general_info#grading'>here</a>. Please note that only persons with Finnish social security number can take part in exams and get official ECTS credits. For the course certificate signup or Finnish social security number are not needed."
       ]
     },
     {
@@ -95,7 +95,7 @@
     {
       "title": "How do I submit the exercises?",
       "text": [
-        "The exercises are submitted to GitHub, and by marking the exercises as done in the exercise submission system. You can read more from <a href='/en/part0/general_info#submitting-exercises'>here</a>. "
+        "The exercises are submitted to GitHub, and by marking the exercises as done in the exercise submission system. You can read more <a href='/en/part0/general_info#submitting-exercises'>here</a>. "
       ]
     },
     {
@@ -129,7 +129,7 @@
       ]
     },
       {
-      "title": "Should I signup to Open University to get the course certificate?",
+      "title": "Should I sign up to Open University to get the course certificate?",
       "text": [
         "For the course certificate signup to Open University is not needed. You can download the certificate after completing the course from the exercise submission system."
       ]


### PR DESCRIPTION
Fixed several typos and a broken link in the English version of the FAQ.