### PR TITLE
Remove parameter from initializing action

### DIFF
--- a/src/content/6/fi/osa6c.md
+++ b/src/content/6/fi/osa6c.md
@@ -265,7 +265,7 @@ Lähestymistapamme on ok, mutta siinä mielessä ikävä, että palvelimen kanss
 const App = (props) => {
 
   useEffect(() => {
-    props.initializeNotes(notes)
+    props.initializeNotes()
   },[])
   // ...
 }


### PR DESCRIPTION
initializeNotes action creator should be called without parameters if I have understood right.