### PR TITLE
Remove remark about addresses being for local dbs

### DIFF
--- a/src/content/4/en/part4b.md
+++ b/src/content/4/en/part4b.md
@@ -109,7 +109,7 @@ module.exports = {
 The code imports the environment variables from the <i>.env</i> file if <i>it is not</i> in production mode. In production mode our application will use the environment variables defined in Heroku.
 
 
-The <i>.env</i> file has <i>separate variables</i> for the database addresses of the development and test databases (the addresses shown in the example are for locally running databases):
+The <i>.env</i> file has <i>separate variables</i> for the database addresses of the development and test databases:
 
 ```bash
 MONGODB_URI=mongodb+srv://fullstack:secred@cluster0-ostce.mongodb.net/note-app?retryWrites=true


### PR DESCRIPTION
Remove the remark in the parenthetical about the addresses being for local databases, because in the immediately following code block, the addresses appear to be for Mongo Atlas. 

If it was referring to something else, I couldn't find it in the document by looking ahead for `mongodb`, nor did I recognize what it was talking about because just prior the text said "we won't be doing a local database, we'll just keep using Mongo Atlas".

If there is something that needs to be clarified here, I'm not sure what it is, so I just removed the confusing parenthetical.